### PR TITLE
Backup and restore opcode while setting sync word

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -404,7 +404,15 @@ void LoRaClass::setPreambleLength(long length)
 
 void LoRaClass::setSyncWord(int sw)
 {
+  // backup current op mode
+  byte oldOpMode = readRegister(REG_OP_MODE);
+
+  sleep();
+
   writeRegister(REG_SYNC_WORD, sw);
+
+  // retore previous op mode
+  writeRegister(REG_OP_MODE, oldOpMode);
 }
 
 void LoRaClass::crc()


### PR DESCRIPTION
As discussed in https://github.com/sandeepmistry/arduino-LoRa/pull/17#discussion_r114056252.

@tigoe I'm still seeing some weirdness with this change, sometime it doesn't look like the new sync word is used on the TX side.