### PR TITLE
Fix SNR register

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -17,8 +17,8 @@
 #define REG_FIFO_RX_CURRENT_ADDR 0x10
 #define REG_IRQ_FLAGS            0x12
 #define REG_RX_NB_BYTES          0x13
+#define REG_PKT_SNR_VALUE        0x19
 #define REG_PKT_RSSI_VALUE       0x1a
-#define REG_PKT_SNR_VALUE        0x1b
 #define REG_MODEM_CONFIG_1       0x1d
 #define REG_MODEM_CONFIG_2       0x1e
 #define REG_PREAMBLE_MSB         0x20


### PR DESCRIPTION
I noticed strange behaviour with the SNR value (sometimes jumping from 10 to 20dB). Also I notices 100% packet loss with +10dB SNR (what can't be true with my understanding of RSSI and SNR).

Datasheet shows SNR register is 0x19, not 0x1b. 0x1b is raw rssi.

After changing the register I got *realistic* values for SNR.

![image](https://user-images.githubusercontent.com/12040515/32689979-fc391a20-c6ee-11e7-9441-379e12d5a659.png)

