### PR TITLE
Stabilize onReceive(...) callback handling

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -281,9 +281,13 @@ void LoRaClass::onReceive(void(*callback)(int))
   if (callback) {
     writeRegister(REG_DIO_MAPPING_1, 0x00);
 
+    SPI.usingInterrupt(digitalPinToInterrupt(_dio0));
     attachInterrupt(digitalPinToInterrupt(_dio0), LoRaClass::onDio0Rise, RISING);
   } else {
     detachInterrupt(digitalPinToInterrupt(_dio0));
+#ifdef SPI_HAS_NOTUSINGINTERRUPT
+    SPI.notUsingInterrupt(digitalPinToInterrupt(_dio0));
+#endif
   }
 }
 

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -280,8 +280,9 @@ void LoRaClass::onReceive(void(*callback)(int))
 
   if (callback) {
     writeRegister(REG_DIO_MAPPING_1, 0x00);
-
+#ifdef SPI_HAS_NOTUSINGINTERRUPT
     SPI.usingInterrupt(digitalPinToInterrupt(_dio0));
+#endif
     attachInterrupt(digitalPinToInterrupt(_dio0), LoRaClass::onDio0Rise, RISING);
   } else {
     detachInterrupt(digitalPinToInterrupt(_dio0));


### PR DESCRIPTION
By using `SPI.usingInterrupt(…)` and `SPI.notUsingInterrupt(…)`.