### PR TITLE
Fix integer warnings

### DIFF
--- a/examples/LoRaDuplex/LoRaDuplex.ino
+++ b/examples/LoRaDuplex/LoRaDuplex.ino
@@ -23,8 +23,8 @@ String outgoing;              // outgoing message
 byte msgCount = 0;            // count of outgoing messages
 byte localAddress = 0xBB;     // address of this device
 byte destination = 0xFF;      // destination to send to
-long lastSendTime = 0;        // last send time
-int interval = 2000;          // interval between sends
+unsigned long lastSendTime = 0;        // last send time
+unsigned int interval = 2000;          // interval between sends
 
 void setup() {
   Serial.begin(9600);                   // initialize serial
@@ -71,10 +71,10 @@ void onReceive(int packetSize) {
   if (packetSize == 0) return;          // if there's no packet, return
 
   // read packet header bytes:
-  int recipient = LoRa.read();          // recipient address
-  byte sender = LoRa.read();            // sender address
-  byte incomingMsgId = LoRa.read();     // incoming msg ID
-  byte incomingLength = LoRa.read();    // incoming msg length
+  byte recipient = (byte)LoRa.read();          // recipient address
+  byte sender = (byte)LoRa.read();            // sender address
+  byte incomingMsgId = (byte)LoRa.read();     // incoming msg ID
+  byte incomingLength = (byte)LoRa.read();    // incoming msg length
 
   String incoming = "";
 


### PR DESCRIPTION
e.g.:
LoRaDuplex.ino:47:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]