### PR TITLE
ensure pin DIO0 is set to input

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -279,6 +279,8 @@ void LoRaClass::onReceive(void(*callback)(int))
   _onReceive = callback;
 
   if (callback) {
+    pinMode(_dio0, INPUT);
+
     writeRegister(REG_DIO_MAPPING_1, 0x00);
 
     attachInterrupt(digitalPinToInterrupt(_dio0), LoRaClass::onDio0Rise, RISING);


### PR DESCRIPTION
Thanks to @BlueCoal69 for suggesting it does work and making me think I missed something. Because.... I missed something.

While I was getting the pin to `INPUT` correctly, I failed to call `LoRa.receive`