### PR TITLE
Add getting the frequency error of a packet

### DIFF
--- a/API.md
+++ b/API.md
@@ -166,6 +166,14 @@ float snr = LoRa.packetSnr();
 
 Returns the estimated SNR of the received packet in dB.
 
+### Packet Frequency Error
+
+```arduino
+long freqErr = LoRa.packetFrequencyError();
+```
+
+Returns the frequency error of the received packet in Hz. The frequency error is the frequency offset between the receiver centre frequency and that of an incoming LoRa signal.
+
 ### Available
 
 ```arduino

--- a/keywords.txt
+++ b/keywords.txt
@@ -49,7 +49,6 @@ random	KEYWORD2
 setPins	KEYWORD2
 setSPIFrequency	KEYWORD2
 dumpRegisters	KEYWORD2
-getSignalBandwidth	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -21,6 +21,7 @@ endPacket	KEYWORD2
 parsePacket	KEYWORD2
 packetRssi	KEYWORD2
 packetSnr	KEYWORD2
+packetFrequencyError	KEYWORD2
 
 write	KEYWORD2
 
@@ -48,6 +49,7 @@ random	KEYWORD2
 setPins	KEYWORD2
 setSPIFrequency	KEYWORD2
 dumpRegisters	KEYWORD2
+getSignalBandwidth	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -27,7 +27,7 @@ public:
   int parsePacket(int size = 0);
   int packetRssi();
   float packetSnr();
-  double packetFrequencyError();
+  long packetFrequencyError();
 
   // from Print
   virtual size_t write(uint8_t byte);
@@ -66,13 +66,13 @@ public:
 
   void dumpRegisters(Stream& out);
 
-  long getSignalBandwidth();
-
 private:
   void explicitHeaderMode();
   void implicitHeaderMode();
 
   void handleDio0Rise();
+
+  long getSignalBandwidth();
 
   uint8_t readRegister(uint8_t address);
   void writeRegister(uint8_t address, uint8_t value);

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -27,6 +27,7 @@ public:
   int parsePacket(int size = 0);
   int packetRssi();
   float packetSnr();
+  double packetFrequencyError();
 
   // from Print
   virtual size_t write(uint8_t byte);
@@ -64,6 +65,8 @@ public:
   void setSPIFrequency(uint32_t frequency);
 
   void dumpRegisters(Stream& out);
+
+  long getSignalBandwidth();
 
 private:
   void explicitHeaderMode();


### PR DESCRIPTION
The LoRa chips frequency can drift over time and with things like the temperature, so a sender and receiver although set to the same frequency might not be on the same frequency. If they are too far apart then packets wont get received. This adds the ability to get the frequency error of a received packet so that you can then adjust the receiver frequency to more closely match that of the sender.

Code copied from my code here that I'd like to move from using the RadioHead LoRa library to use your one: https://github.com/HarringayMakerSpace/HabitatLoraGateway

