### PR TITLE
Adding function for compensating frequency and ppm offset

### DIFF
--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -54,6 +54,8 @@ public:
   void enableCrc();
   void disableCrc();
 
+  float compensateFrequencyOffset();
+
   // deprecated
   void crc() { enableCrc(); }
   void noCrc() { disableCrc(); }
@@ -82,7 +84,8 @@ private:
   int _ss;
   int _reset;
   int _dio0;
-  int _frequency;
+  long _frequency;
+  long _bandWidth;
   int _packetIndex;
   int _implicitHeaderMode;
   void (*_onReceive)(int);


### PR DESCRIPTION
Call this function once after a successful package reception and
the centre frequency will be modified with the error indicated by
the LoRa chip. Along with this, PPM drift compensation also occurs.

The function returns the amount of the compensation needed.

Two more bug fixes:
- _frequency could be zero, now set to its default
- _frequency was stored only in `int` (aka `int16_t`) which caused that
  the stored value could be maximum 32767 Hz, not e.g. 930 000 000 Hz.
  - Because of this `packetRssi()` possible didn't work properly.

Please, independently check the validity of my calculation.