### PR TITLE
Correctly set Tx dBm level in RFO mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -225,10 +225,10 @@ LoRa.setTxPower(txPower);
 
 LoRa.setTxPower(txPower, outputPin);
 ```
- * `txPower` - TX power in dB, defaults to `17`
- * `outputPin` - (optional) PA output pin, supported values are `PA_OUTPUT_RFO_PIN` and `PA_OUTPUT_PA_BOOST_PIN`, defaults to `PA_OUTPUT_PA_BOOST_PIN`.
+ * `txPower` - TX power in dBm, defaults to `17`
+ * `outputPin` - (optional) Power Amplifier output pin, supported values are `PA_OUTPUT_RFO_PIN` and `PA_OUTPUT_PA_BOOST_PIN`, defaults to `PA_OUTPUT_PA_BOOST_PIN`.
 
-Supported values are between `2` and `17` for `PA_OUTPUT_PA_BOOST_PIN`, `0` and `14` for `PA_OUTPUT_RFO_PIN`.
+Supported values are between `2` and `17` for `PA_OUTPUT_PA_BOOST_PIN`, `-1` and `14` for `PA_OUTPUT_RFO_PIN`.
 
 Most modules have the PA output pin connected to PA BOOST,
 

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -316,13 +316,13 @@ void LoRaClass::setTxPower(int level, int outputPin)
 {
   if (PA_OUTPUT_RFO_PIN == outputPin) {
     // RFO
-    if (level < 0) {
-      level = 0;
+    if (level < -1) {
+      level = -1;
     } else if (level > 14) {
       level = 14;
     }
 
-    writeRegister(REG_PA_CONFIG, 0x70 | level);
+    writeRegister(REG_PA_CONFIG, 0x70 | (level + 1));
   } else {
     // PA BOOST
     if (level < 2) {


### PR DESCRIPTION
Previously it was between [-1..13] dBm and now it is between [-1..14] dBm.
Deceptively, all previously user-set values were set to "desired -1" dBm in practice.

14 in binary is B1110 while 15 is B1111. The maximum value of RegPaConfig
OutputPower is also B1111.

See also Semtech's own implementation and comments in:
- https://github.com/Lora-net/LoRaMac-node/blob/master/src/radio/sx1276/sx1276.c#L364
- https://github.com/Lora-net/LoRaMac-node/blob/master/src/boards/NucleoL152/sx1276mb1mas-board.c#L205