### PR TITLE
Changed private to protected to enable more flexible

### DIFF
--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -66,7 +66,7 @@ public:
 
   void dumpRegisters(Stream& out);
 
-private:
+protected:
   void explicitHeaderMode();
   void implicitHeaderMode();
 


### PR DESCRIPTION
Changed private to protected to enable more extension through inheritance.

Hi,

In my scenario I would like to use your class as a parent where the subclass can add methods that use the base methods for reading and writing the hardware registers.  

Jonathan.