### PR TITLE
Better random number generation from RSSI

### DIFF
--- a/API.md
+++ b/API.md
@@ -343,7 +343,7 @@ Returns RSSI value as a byte.
 
 ### Random
 
-Generate a random byte, based on the Wideband RSSI measurement run through a von Neumann Extractor.
+Generate a random byte, based on the Wideband RSSI measurement run through a von Neumann Extractor. **NB** - these are not cryptographically secure random numbers! Use with caution!
 
 ```
 byte b = LoRa.random();

--- a/API.md
+++ b/API.md
@@ -331,9 +331,19 @@ LoRa.disableCrc();
 
 ## Other functions
 
+### Get RSSI
+
+Gets the RSSI value from the radio. 
+
+```
+byte b = LoRa.getRSSI();
+```
+
+Returns RSSI value as a byte.
+
 ### Random
 
-Generate a random byte, based on the Wideband RSSI measurement.
+Generate a random byte, based on the Wideband RSSI measurement run through a von Neumann Extractor.
 
 ```
 byte b = LoRa.random();

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -512,9 +512,28 @@ void LoRaClass::disableCrc()
   writeRegister(REG_MODEM_CONFIG_2, readRegister(REG_MODEM_CONFIG_2) & 0xfb);
 }
 
+byte LoRaClass::getRSSI()
+{
+    return readRegister(REG_RSSI_WIDEBAND);
+}
+
 byte LoRaClass::random()
 {
-  return readRegister(REG_RSSI_WIDEBAND);
+  int n=0, bits=7;
+  while(bits--) {
+    n<<=1;
+    while(1){
+      // implement a basic von Neumann Extractor
+      int a=(readRegister(REG_RSSI_WIDEBAND) & 1);
+      if(a != (readRegister(REG_RSSI_WIDEBAND) & 1)){
+        // put random, whitened bit in n
+        n |= a;
+        break;
+      }
+    }
+  }
+  // return the random byte
+  return n;
 }
 
 void LoRaClass::setPins(int ss, int reset, int dio0)

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -71,6 +71,7 @@ public:
   void crc() { enableCrc(); }
   void noCrc() { disableCrc(); }
 
+  byte getRSSI();
   byte random();
 
   void setPins(int ss = LORA_DEFAULT_SS_PIN, int reset = LORA_DEFAULT_RESET_PIN, int dio0 = LORA_DEFAULT_DIO0_PIN);


### PR DESCRIPTION
Hello,
The API call LoRa.random() gave users really bad random numbers. They need some level of whitening in order to be useful, so I've added some rather dirty (sorry!) code to implement a von Neumann Extractor. It's normally implemented in three functions, but I didn't want to bloat the class - feel free to edit it to make it more stylistic if you like :) See here for more information: https://en.wikipedia.org/wiki/Randomness_extractor#Von_Neumann_extractor

I tested the code that was originally there, and the random numbers were disappointing - I can send samples if you would like. This code will generate better random numbers. I also added a warning that these are not cryptographically secure, as I haven't proven that they are otherwise yet. :P

The speed is slightly slower, but very fast in the grander scheme of things (other entropy pools take a long time to generate entropy). I'm happy to answer any questions. 

Many thanks! M.