### PR TITLE
Add function to invert IQ signal register

### DIFF
--- a/API.md
+++ b/API.md
@@ -331,12 +331,13 @@ LoRa.disableCrc();
 
 ### Invert IQ Signals
 
-Invert the LoRa I and Q signals, by default a invertIQ is not used.
+Enable or disable Invert the LoRa I and Q signals, by default a invertIQ is not used.
 
 ```arduino
-LoRa.invertIQ(invert);
+LoRa.enableInvertIQ();
+
+LoRa.disableInvertIQ();
 ```
- * `invert` - `false` normal mode, `true` IQ signals are inverted.
 
 ## Other functions
 

--- a/API.md
+++ b/API.md
@@ -329,6 +329,15 @@ LoRa.enableCrc();
 LoRa.disableCrc();
 ```
 
+### Invert IQ Signals
+
+Invert the LoRa I and Q signals, by default a invertIQ is not used.
+
+```arduino
+LoRa.invertIQ(invert);
+```
+ * `invert` - `false` normal mode, `true` IQ signals are inverted.
+
 ## Other functions
 
 ### Random

--- a/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
+++ b/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
@@ -34,7 +34,7 @@ const int resetPin = 9;        // LoRa radio reset
 const int irqPin = 2;          // change for your board; must be a hardware interrupt pin
 
 void setup() {
-  Serial.begin(115200);                   // initialize serial
+  Serial.begin(9600);                   // initialize serial
   while (!Serial);
 
   LoRa.setPins(csPin, resetPin, irqPin);

--- a/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
+++ b/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
@@ -4,16 +4,16 @@
   This code uses InvertIQ function to create a simple Gateway/Node logic.
 
   Gateway - Sends messages with enableInvertIQ()
-          - Receives messeges with disableInvertIQ()
+          - Receives messages with disableInvertIQ()
 
   Node    - Sends messages with disableInvertIQ()
-          - Receives messeges with enableInvertIQ()
+          - Receives messages with enableInvertIQ()
 
-  With this arrangement a Gateway never receive messagem from another Gateway 
+  With this arrangement a Gateway never receive messages from another Gateway
   and a Node never receive message from another Node.
   Only Gateway to Node and vice versa.
 
-  This code receives messagens and sends a message every second.
+  This code receives messages and sends a message every second.
 
   InvertIQ function basically invert the LoRa I and Q signals.
 
@@ -59,7 +59,7 @@ void setup() {
 void loop() {
   if (runEvery(5000)) { // repeat every 5000 millis
 
-    String message = "HeLoRa World! ";   
+    String message = "HeLoRa World! ";
     message += "I'm a Gateway! ";
     message += millis();
 
@@ -89,7 +89,7 @@ void LoRa_sendMessage(String message) {
 
 void onReceive(int packetSize) {
   String message = "";
-  
+
   while (LoRa.available()) {
     message += (char)LoRa.read();
   }
@@ -99,7 +99,7 @@ void onReceive(int packetSize) {
 
 }
 
-boolean runEvery(unsigned long interval) 
+boolean runEvery(unsigned long interval)
 {
   static unsigned long previousMillis = 0;
   unsigned long currentMillis = millis();

--- a/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
+++ b/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
@@ -1,0 +1,113 @@
+/*
+  LoRa Simple Gateway/Node Exemple
+
+  This code uses InvertIQ function to create a simple Gateway/Node logic.
+
+  Gateway - Sends messages with InvertIQ(true)
+          - Receives messeges with InvertIQ(false)
+
+  Node    - Sends messages with InvertIQ(false)
+          - Receives messeges with InvertIQ(true)
+
+  With this arrangement a Gateway never receive messagem from another Gateway 
+  and a Node never receive message from another Node.
+  Only Gateway to Node and vice versa.
+
+  This code receives messagens and sends a message every second.
+
+  InvertIQ function basically invert the LoRa I and Q signals.
+
+  See the Semtech datasheet, http://www.semtech.com/images/datasheet/sx1276.pdf
+  for more on InvertIQ register 0x33.
+
+  created 05 August 2018
+  by Luiz H. Cassettari
+*/
+
+#include <SPI.h>              // include libraries
+#include <LoRa.h>
+
+const long frequency = 915E6;  // LoRa Frequency
+
+const int csPin = 10;          // LoRa radio chip select
+const int resetPin = 9;        // LoRa radio reset
+const int irqPin = 2;          // change for your board; must be a hardware interrupt pin
+
+void setup() {
+  Serial.begin(115200);                   // initialize serial
+  while (!Serial);
+
+  LoRa.setPins(csPin, resetPin, irqPin);
+
+  if (!LoRa.begin(frequency)) {
+    Serial.println("LoRa init failed. Check your connections.");
+    while (true);                       // if failed, do nothing
+  }
+
+  Serial.println("LoRa init succeeded.");
+  Serial.println();
+  Serial.println("LoRa Simple Gateway");
+  Serial.println("Only receive messages from nodes");
+  Serial.println("Tx: invertIQ = true");
+  Serial.println("Rx: invertIQ = false");
+  Serial.println();
+
+  LoRa.onReceive(onReceive);
+  LoRa_rxMode();
+}
+
+void loop() {
+  if (runEvery(5000)) { // repeat every 5000 millis
+
+    String message = "HeLoRa World! ";   
+    message += "I'm a Gateway! ";
+    message += millis();
+
+    LoRa_sendMessage(message); // send a message
+
+    Serial.println("Send Message!");
+  }
+}
+
+void LoRa_rxMode(){
+  LoRa.invertIQ(false);                 // normal mode
+  LoRa.receive();                       // set receive mode
+}
+
+void LoRa_txMode(){
+  LoRa.idle();                          // set standby mode
+  LoRa.invertIQ(true);                  // active invert I and Q signals
+}
+
+void LoRa_sendMessage(String message) {
+  LoRa_txMode();                        // set tx mode
+  LoRa.beginPacket();                   // start packet
+  LoRa.print(message);                  // add payload
+  LoRa.endPacket();                     // finish packet and send it
+  LoRa_rxMode();                        // set rx mode
+}
+
+void onReceive(int packetSize) {
+  String message = "";
+  
+  while (LoRa.available()) {
+    message += (char)LoRa.read();
+  }
+
+  Serial.print("Gateway Receive: ");
+  Serial.println(message);
+
+}
+
+boolean runEvery(unsigned long interval) 
+{
+  static unsigned long previousMillis = 0;
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval)
+  {
+    previousMillis = currentMillis;
+    return true;
+  }
+  return false;
+}
+

--- a/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
+++ b/examples/LoRaSimpleGateway/LoRaSimpleGateway.ino
@@ -3,11 +3,11 @@
 
   This code uses InvertIQ function to create a simple Gateway/Node logic.
 
-  Gateway - Sends messages with InvertIQ(true)
-          - Receives messeges with InvertIQ(false)
+  Gateway - Sends messages with enableInvertIQ()
+          - Receives messeges with disableInvertIQ()
 
-  Node    - Sends messages with InvertIQ(false)
-          - Receives messeges with InvertIQ(true)
+  Node    - Sends messages with disableInvertIQ()
+          - Receives messeges with enableInvertIQ()
 
   With this arrangement a Gateway never receive messagem from another Gateway 
   and a Node never receive message from another Node.
@@ -48,8 +48,8 @@ void setup() {
   Serial.println();
   Serial.println("LoRa Simple Gateway");
   Serial.println("Only receive messages from nodes");
-  Serial.println("Tx: invertIQ = true");
-  Serial.println("Rx: invertIQ = false");
+  Serial.println("Tx: invertIQ enable");
+  Serial.println("Rx: invertIQ disable");
   Serial.println();
 
   LoRa.onReceive(onReceive);
@@ -70,13 +70,13 @@ void loop() {
 }
 
 void LoRa_rxMode(){
-  LoRa.invertIQ(false);                 // normal mode
+  LoRa.disableInvertIQ();               // normal mode
   LoRa.receive();                       // set receive mode
 }
 
 void LoRa_txMode(){
   LoRa.idle();                          // set standby mode
-  LoRa.invertIQ(true);                  // active invert I and Q signals
+  LoRa.enableInvertIQ();                // active invert I and Q signals
 }
 
 void LoRa_sendMessage(String message) {

--- a/examples/LoRaSimpleNode/LoRaSimpleNode.ino
+++ b/examples/LoRaSimpleNode/LoRaSimpleNode.ino
@@ -3,11 +3,11 @@
 
   This code uses InvertIQ function to create a simple Gateway/Node logic.
 
-  Gateway - Sends messages with InvertIQ(true)
-          - Receives messeges with InvertIQ(false)
+  Gateway - Sends messages with enableInvertIQ()
+          - Receives messeges with disableInvertIQ()
 
-  Node    - Sends messages with InvertIQ(false)
-          - Receives messeges with InvertIQ(true)
+  Node    - Sends messages with disableInvertIQ()
+          - Receives messeges with enableInvertIQ()
 
   With this arrangement a Gateway never receive messagem from another Gateway 
   and a Node never receive message from another Node.
@@ -48,8 +48,8 @@ void setup() {
   Serial.println();
   Serial.println("LoRa Simple Node");
   Serial.println("Only receive messages from gateways");
-  Serial.println("Tx: invertIQ = false");
-  Serial.println("Rx: invertIQ = true");
+  Serial.println("Tx: invertIQ disable");
+  Serial.println("Rx: invertIQ enable");
   Serial.println();
 
   LoRa.onReceive(onReceive);
@@ -70,13 +70,13 @@ void loop() {
 }
 
 void LoRa_rxMode(){
-  LoRa.invertIQ(true);                  // active invert I and Q signals
+  LoRa.enableInvertIQ();                // active invert I and Q signals
   LoRa.receive();                       // set receive mode
 }
 
 void LoRa_txMode(){
   LoRa.idle();                          // set standby mode
-  LoRa.invertIQ(false);                 // normal mode
+  LoRa.disableInvertIQ();               // normal mode
 }
 
 void LoRa_sendMessage(String message) {

--- a/examples/LoRaSimpleNode/LoRaSimpleNode.ino
+++ b/examples/LoRaSimpleNode/LoRaSimpleNode.ino
@@ -34,7 +34,7 @@ const int resetPin = 9;        // LoRa radio reset
 const int irqPin = 2;          // change for your board; must be a hardware interrupt pin
 
 void setup() {
-  Serial.begin(115200);                   // initialize serial
+  Serial.begin(9600);                   // initialize serial
   while (!Serial);
 
   LoRa.setPins(csPin, resetPin, irqPin);

--- a/examples/LoRaSimpleNode/LoRaSimpleNode.ino
+++ b/examples/LoRaSimpleNode/LoRaSimpleNode.ino
@@ -1,0 +1,113 @@
+/*
+  LoRa Simple Gateway/Node Exemple
+
+  This code uses InvertIQ function to create a simple Gateway/Node logic.
+
+  Gateway - Sends messages with InvertIQ(true)
+          - Receives messeges with InvertIQ(false)
+
+  Node    - Sends messages with InvertIQ(false)
+          - Receives messeges with InvertIQ(true)
+
+  With this arrangement a Gateway never receive messagem from another Gateway 
+  and a Node never receive message from another Node.
+  Only Gateway to Node and vice versa.
+
+  This code receives messagens and sends a message every second.
+
+  InvertIQ function basically invert the LoRa I and Q signals.
+
+  See the Semtech datasheet, http://www.semtech.com/images/datasheet/sx1276.pdf
+  for more on InvertIQ register 0x33.
+
+  created 05 August 2018
+  by Luiz H. Cassettari
+*/
+
+#include <SPI.h>              // include libraries
+#include <LoRa.h>
+
+const long frequency = 915E6;  // LoRa Frequency
+
+const int csPin = 10;          // LoRa radio chip select
+const int resetPin = 9;        // LoRa radio reset
+const int irqPin = 2;          // change for your board; must be a hardware interrupt pin
+
+void setup() {
+  Serial.begin(115200);                   // initialize serial
+  while (!Serial);
+
+  LoRa.setPins(csPin, resetPin, irqPin);
+
+  if (!LoRa.begin(frequency)) {
+    Serial.println("LoRa init failed. Check your connections.");
+    while (true);                       // if failed, do nothing
+  }
+
+  Serial.println("LoRa init succeeded.");
+  Serial.println();
+  Serial.println("LoRa Simple Node");
+  Serial.println("Only receive messages from gateways");
+  Serial.println("Tx: invertIQ = false");
+  Serial.println("Rx: invertIQ = true");
+  Serial.println();
+
+  LoRa.onReceive(onReceive);
+  LoRa_rxMode();
+}
+
+void loop() {
+  if (runEvery(1000)) { // repeat every 1000 millis
+
+    String message = "HeLoRa World! ";   
+    message += "I'm a Node! ";
+    message += millis();
+
+    LoRa_sendMessage(message); // send a message
+
+    Serial.println("Send Message!");
+  }
+}
+
+void LoRa_rxMode(){
+  LoRa.invertIQ(true);                  // active invert I and Q signals
+  LoRa.receive();                       // set receive mode
+}
+
+void LoRa_txMode(){
+  LoRa.idle();                          // set standby mode
+  LoRa.invertIQ(false);                 // normal mode
+}
+
+void LoRa_sendMessage(String message) {
+  LoRa_txMode();                        // set tx mode
+  LoRa.beginPacket();                   // start packet
+  LoRa.print(message);                  // add payload
+  LoRa.endPacket();                     // finish packet and send it
+  LoRa_rxMode();                        // set rx mode
+}
+
+void onReceive(int packetSize) {
+  String message = "";
+  
+  while (LoRa.available()) {
+    message += (char)LoRa.read();
+  }
+
+  Serial.print("Node Receive: ");
+  Serial.println(message);
+
+}
+
+boolean runEvery(unsigned long interval) 
+{
+  static unsigned long previousMillis = 0;
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval)
+  {
+    previousMillis = currentMillis;
+    return true;
+  }
+  return false;
+}
+

--- a/examples/LoRaSimpleNode/LoRaSimpleNode.ino
+++ b/examples/LoRaSimpleNode/LoRaSimpleNode.ino
@@ -4,16 +4,16 @@
   This code uses InvertIQ function to create a simple Gateway/Node logic.
 
   Gateway - Sends messages with enableInvertIQ()
-          - Receives messeges with disableInvertIQ()
+          - Receives messages with disableInvertIQ()
 
   Node    - Sends messages with disableInvertIQ()
-          - Receives messeges with enableInvertIQ()
+          - Receives messages with enableInvertIQ()
 
-  With this arrangement a Gateway never receive messagem from another Gateway 
+  With this arrangement a Gateway never receive messages from another Gateway
   and a Node never receive message from another Node.
   Only Gateway to Node and vice versa.
 
-  This code receives messagens and sends a message every second.
+  This code receives messages and sends a message every second.
 
   InvertIQ function basically invert the LoRa I and Q signals.
 
@@ -59,7 +59,7 @@ void setup() {
 void loop() {
   if (runEvery(1000)) { // repeat every 1000 millis
 
-    String message = "HeLoRa World! ";   
+    String message = "HeLoRa World! ";
     message += "I'm a Node! ";
     message += millis();
 
@@ -89,7 +89,7 @@ void LoRa_sendMessage(String message) {
 
 void onReceive(int packetSize) {
   String message = "";
-  
+
   while (LoRa.available()) {
     message += (char)LoRa.read();
   }
@@ -99,7 +99,7 @@ void onReceive(int packetSize) {
 
 }
 
-boolean runEvery(unsigned long interval) 
+boolean runEvery(unsigned long interval)
 {
   static unsigned long previousMillis = 0;
   unsigned long currentMillis = millis();

--- a/keywords.txt
+++ b/keywords.txt
@@ -44,13 +44,13 @@ setPreambleLength	KEYWORD2
 setSyncWord	KEYWORD2
 enableCrc	KEYWORD2
 disableCrc	KEYWORD2
+enableInvertIQ  KEYWORD2
+disableInvertIQ KEYWORD2
 
 random	KEYWORD2
 setPins	KEYWORD2
 setSPIFrequency	KEYWORD2
 dumpRegisters	KEYWORD2
-
-invertIQ KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -50,6 +50,8 @@ setPins	KEYWORD2
 setSPIFrequency	KEYWORD2
 dumpRegisters	KEYWORD2
 
+invertIQ KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LoRa
-version=0.4.0
+version=0.5.0
 author=Sandeep Mistry <sandeep.mistry@gmail.com>
 maintainer=Sandeep Mistry <sandeep.mistry@gmail.com>
 sentence=An Arduino library for sending and receiving data using LoRa radios.

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -30,7 +30,7 @@
 #define REG_FREQ_ERROR_LSB       0x2a
 #define REG_RSSI_WIDEBAND        0x2c
 #define REG_DETECTION_OPTIMIZE   0x31
-#define REG_INVERTIQ             0x33 // (default 0x27 or 0x40)
+#define REG_INVERTIQ             0x33 // (default 0x27 or 0x66)
 #define REG_DETECTION_THRESHOLD  0x37
 #define REG_SYNC_WORD            0x39
 #define REG_DIO_MAPPING_1        0x40
@@ -618,7 +618,12 @@ void LoRaClass::onDio0Rise()
 
 void LoRaClass::invertIQ(boolean invert)
 {
-  writeRegister(REG_INVERTIQ, (uint8_t) (invert == false ?  0x27 : 0x40));
+  // https://github.com/intel-iot-devkit/upm/blob/master/src/sx1276/sx1276.cxx
+  // The datasheet does not mention anything other than an
+  // InvertIQ bit (0x40) in RegInvertIQ register (0x33).  Here,
+  // we seem to have two bits in RegInvertIQ (existing one for
+  // RX), and a 'new' one for TXOff (0x01).
+  writeRegister(REG_INVERTIQ, (uint8_t) (invert == false ?  0x27 : 0x66));
 }
 
 LoRaClass LoRa;

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -30,10 +30,10 @@
 #define REG_FREQ_ERROR_LSB       0x2a
 #define REG_RSSI_WIDEBAND        0x2c
 #define REG_DETECTION_OPTIMIZE   0x31
-#define REG_INVERTIQ             0x33 // (default 0x27 or 0x66)
+#define REG_INVERTIQ             0x33
 #define REG_DETECTION_THRESHOLD  0x37
 #define REG_SYNC_WORD            0x39
-#define REG_INVERTIQ2            0x3b // does not exist in datasheet // but used in Semtech code. // UNDOCUMENTED
+#define REG_INVERTIQ2            0x3b
 #define REG_DIO_MAPPING_1        0x40
 #define REG_VERSION              0x42
 
@@ -627,8 +627,7 @@ void LoRaClass::invertIQ(boolean invert)
   // INVERTIQ2 (0x3b) does not exist in the datasheet, it is
   // marked as reserved. We will assume that the datasheet is
   // out of date.
-  
-  writeRegister(REG_INVERTIQ, (uint8_t) (invert == false ?  0x27 : 0x66));
+  writeRegister(REG_INVERTIQ,  invert == false ? 0x27 : 0x66);
   writeRegister(REG_INVERTIQ2, invert == false ? 0x1d : 0x19);
 }
 

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -33,6 +33,7 @@
 #define REG_INVERTIQ             0x33 // (default 0x27 or 0x66)
 #define REG_DETECTION_THRESHOLD  0x37
 #define REG_SYNC_WORD            0x39
+#define REG_INVERTIQ2            0x3b // does not exist in datasheet // but used in Semtech code. // UNDOCUMENTED
 #define REG_DIO_MAPPING_1        0x40
 #define REG_VERSION              0x42
 
@@ -622,8 +623,13 @@ void LoRaClass::invertIQ(boolean invert)
   // The datasheet does not mention anything other than an
   // InvertIQ bit (0x40) in RegInvertIQ register (0x33).  Here,
   // we seem to have two bits in RegInvertIQ (existing one for
-  // RX), and a 'new' one for TXOff (0x01).
+  // RX), and a 'new' one for TXOff (0x01).  In addition,
+  // INVERTIQ2 (0x3b) does not exist in the datasheet, it is
+  // marked as reserved. We will assume that the datasheet is
+  // out of date.
+  
   writeRegister(REG_INVERTIQ, (uint8_t) (invert == false ?  0x27 : 0x66));
+  writeRegister(REG_INVERTIQ2, invert == false ? 0x1d : 0x19);
 }
 
 LoRaClass LoRa;

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -514,6 +514,18 @@ void LoRaClass::disableCrc()
   writeRegister(REG_MODEM_CONFIG_2, readRegister(REG_MODEM_CONFIG_2) & 0xfb);
 }
 
+void LoRaClass::enableInvertIQ()
+{
+  writeRegister(REG_INVERTIQ,  0x66);
+  writeRegister(REG_INVERTIQ2, 0x19);
+}
+
+void LoRaClass::disableInvertIQ()
+{
+  writeRegister(REG_INVERTIQ,  0x27);
+  writeRegister(REG_INVERTIQ2, 0x1d);
+}
+
 byte LoRaClass::random()
 {
   return readRegister(REG_RSSI_WIDEBAND);
@@ -615,20 +627,6 @@ uint8_t LoRaClass::singleTransfer(uint8_t address, uint8_t value)
 void LoRaClass::onDio0Rise()
 {
   LoRa.handleDio0Rise();
-}
-
-void LoRaClass::invertIQ(boolean invert)
-{
-  // https://github.com/intel-iot-devkit/upm/blob/master/src/sx1276/sx1276.cxx
-  // The datasheet does not mention anything other than an
-  // InvertIQ bit (0x40) in RegInvertIQ register (0x33).  Here,
-  // we seem to have two bits in RegInvertIQ (existing one for
-  // RX), and a 'new' one for TXOff (0x01).  In addition,
-  // INVERTIQ2 (0x3b) does not exist in the datasheet, it is
-  // marked as reserved. We will assume that the datasheet is
-  // out of date.
-  writeRegister(REG_INVERTIQ,  invert == false ? 0x27 : 0x66);
-  writeRegister(REG_INVERTIQ2, invert == false ? 0x1d : 0x19);
 }
 
 LoRaClass LoRa;

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -79,7 +79,7 @@ public:
   void setSPIFrequency(uint32_t frequency);
 
   void dumpRegisters(Stream& out);
-  
+
 private:
   void explicitHeaderMode();
   void implicitHeaderMode();

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -66,7 +66,8 @@ public:
   void setSyncWord(int sw);
   void enableCrc();
   void disableCrc();
-
+  void invertIQ(boolean invert);
+  
   // deprecated
   void crc() { enableCrc(); }
   void noCrc() { disableCrc(); }
@@ -78,8 +79,6 @@ public:
   void setSPIFrequency(uint32_t frequency);
 
   void dumpRegisters(Stream& out);
-
-  void invertIQ(boolean invert);
   
 private:
   void explicitHeaderMode();

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -74,8 +74,6 @@ public:
   // deprecated
   void crc() { enableCrc(); }
   void noCrc() { disableCrc(); }
-  void invertIQ() { enableInvertIQ(); }
-  void noInvertIQ() { disableInvertIQ(); }
 
   byte random();
 

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -66,11 +66,14 @@ public:
   void setSyncWord(int sw);
   void enableCrc();
   void disableCrc();
-  void invertIQ(boolean invert);
+  void enableInvertIQ();
+  void disableInvertIQ();
   
   // deprecated
   void crc() { enableCrc(); }
   void noCrc() { disableCrc(); }
+  void invertIQ() { enableInvertIQ(); }
+  void noInvertIQ() { disableInvertIQ(); }
 
   byte random();
 

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -79,6 +79,8 @@ public:
 
   void dumpRegisters(Stream& out);
 
+  void invertIQ(boolean invert);
+  
 private:
   void explicitHeaderMode();
   void implicitHeaderMode();


### PR DESCRIPTION
InvertIQ allows differentiating sender and receiver message.

Usually, Gateways read messages with InvertIQ off and send messages with InvertIQ on, Nodes read messages with InvertIQ on and send messages with InvertIQ off.

This way a Gateway only reads messages from Nodes and never reads messages from other Gateway, and Node never reads messages from other Node.