### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -44,8 +44,8 @@ setPreambleLength	KEYWORD2
 setSyncWord	KEYWORD2
 enableCrc	KEYWORD2
 disableCrc	KEYWORD2
-enableInvertIQ  KEYWORD2
-disableInvertIQ KEYWORD2
+enableInvertIQ	KEYWORD2
+disableInvertIQ	KEYWORD2
 
 random	KEYWORD2
 setPins	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords