### PR TITLE
isTransmitting() public

### DIFF
--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -15,7 +15,7 @@
 #define LORA_DEFAULT_DIO0_PIN      -1
 #else
 #define LORA_DEFAULT_SPI           SPI
-#define LORA_DEFAULT_SPI_FREQUENCY 8E6 
+#define LORA_DEFAULT_SPI_FREQUENCY 8E6
 #define LORA_DEFAULT_SS_PIN        10
 #define LORA_DEFAULT_RESET_PIN     9
 #define LORA_DEFAULT_DIO0_PIN      2
@@ -33,6 +33,7 @@ public:
 
   int beginPacket(int implicitHeader = false);
   int endPacket(bool async = false);
+  bool isTransmitting();
 
   int parsePacket(int size = 0);
   int packetRssi();
@@ -68,7 +69,7 @@ public:
   void disableCrc();
   void enableInvertIQ();
   void disableInvertIQ();
-  
+
   void setOCP(uint8_t mA); // Over Current Protection control
 
   // deprecated
@@ -88,7 +89,6 @@ private:
   void implicitHeaderMode();
 
   void handleDio0Rise();
-  bool isTransmitting();
 
   int getSpreadingFactor();
   long getSignalBandwidth();


### PR DESCRIPTION
Hi,
I just updated the `isTransmitting()` method to be public.
When transmitting using the blocking functions added in #62 this function is necessary externally to calculate transmission time (to respect duty cycles).
BTW, it would be very useful to have a lower level function to get actual transmission time of the last sent packet.