### PR TITLE
Improve on random()

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -582,7 +582,18 @@ void LoRaClass::setOCP(uint8_t mA)
 
 byte LoRaClass::random()
 {
-  return readRegister(REG_RSSI_WIDEBAND);
+  uint8_t currMode = readRegister(REG_OP_MODE);
+  uint8_t retVal = 0;
+  
+  while(isTransmitting());
+
+  //We need to be listening to radio-traffic in order to generate random numbers
+  if(currMode != (MODE_LONG_RANGE_MODE | MODE_RX_CONTINUOUS)){ receive(); delay(1); }
+  retVal = readRegister(REG_RSSI_WIDEBAND);
+  //Put the radio in the same mode as it was
+  if(currMode != (MODE_LONG_RANGE_MODE | MODE_RX_CONTINUOUS)) writeRegister(REG_OP_MODE, currMode);
+
+  return retVal;
 }
 
 void LoRaClass::setPins(int ss, int reset, int dio0)


### PR DESCRIPTION
The original code doesn't check for what mode the radio is in and
returns 0, if the radio isn't in listening-mode; this code-change
waits until any queued packets have been transmitted, checks the
current mode, changes it to listening-mode, gets the random value
and then proceeds to change the mode back to whatever it was.