### PR TITLE
Fix incorrect sync word in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -317,7 +317,7 @@ Change the sync word of the radio.
 LoRa.setSyncWord(syncWord);
 ```
 
- * `syncWord` - byte value to use as the sync word, defaults to `0x34`
+ * `syncWord` - byte value to use as the sync word, defaults to `0x12`
 
 ### CRC
 


### PR DESCRIPTION
API currently states the default sync word is 0x34 when in fact it\'s 0x12. 0x34 is the sync word when using LoRaWAN