### PR TITLE
Update LoRa.cpp

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -231,7 +231,8 @@ size_t LoRaClass::write(const uint8_t *buffer, size_t size)
   }
 
   // update length
-  writeRegister(REG_PAYLOAD_LENGTH, currentLength + size);
+  //writeRegister(REG_PAYLOAD_LENGTH, currentLength + size);
+  writeRegister(REG_PAYLOAD_LENGTH, size);
 
   return size;
 }


### PR DESCRIPTION
If "currentLength" is incorporated, the payload length exponentially increases even though the payload written to the buffer remains unchanged over sequential iterations. I have tested my pull request and the new code works.