### PR TITLE
Corrects conditional compilation problem on ESP8266 and ESP32

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -57,7 +57,7 @@
 
 #define MAX_PKT_LENGTH           255
 
-#ifdef ESP8266 || ESP32
+#if (ESP8266 || ESP32)
     #define ISR_PREFIX ICACHE_RAM_ATTR
 #else
     #define ISR_PREFIX


### PR DESCRIPTION
Version 0.6.0 introduced a mechanism to supply the ICACHE_RAM_ATTR
prefix to the onDio0Rise() interrupt service routine when compiling
for ESP32 or ESP8266 boards. As written, "#ifdef ESP8266 || ESP32"
produces "warning: extra tokens at end of #ifdef directive" when
compiling in the Arduino IDE 1.8.9. If the board is an ESP8266 then
ISR_PREFIX has the value ICACHE_RAM_ATTR (correct) but if the board is
an ESP32, ISR_PREFIX is null (incorrect) This PR proposes alternative
syntax "#if (ESP8266 || ESP32)" which compiles without warning and
provides ICACHE_RAM_ATTR to both ESP8266 and ESP32 boards.