### PR TITLE
fix mid band threshold and add function to get current RSSI value

### DIFF
--- a/API.md
+++ b/API.md
@@ -169,7 +169,7 @@ The `onReceive` callback will be called when a packet is received.
 ### Packet RSSI
 
 ```arduino
-int pRssi = LoRa.packetRssi();
+int rssi = LoRa.packetRssi();
 ```
 
 Returns the averaged RSSI of the last received packet (dBm).

--- a/API.md
+++ b/API.md
@@ -169,10 +169,10 @@ The `onReceive` callback will be called when a packet is received.
 ### Packet RSSI
 
 ```arduino
-int rssi = LoRa.packetRssi();
+int pRssi = LoRa.packetRssi();
 ```
 
-Returns the RSSI of the received packet.
+Returns the averaged RSSI of the last received packet (dBm).
 
 ### Packet SNR
 
@@ -181,6 +181,14 @@ float snr = LoRa.packetSnr();
 ```
 
 Returns the estimated SNR of the received packet in dB.
+
+## RSSI
+
+```arduino
+int rssi = LoRa.rssi();
+```
+
+Returns the current RSSI of the radio (dBm).
 
 ### Packet Frequency Error
 

--- a/API.md
+++ b/API.md
@@ -188,7 +188,7 @@ Returns the estimated SNR of the received packet in dB.
 int rssi = LoRa.rssi();
 ```
 
-Returns the current RSSI of the radio (dBm).
+Returns the current RSSI of the radio (dBm). RSSI can be read at any time (during packet reception or not)
 
 ### Packet Frequency Error
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,8 @@ packetRssi	KEYWORD2
 packetSnr	KEYWORD2
 packetFrequencyError	KEYWORD2
 
+rssi	KEYWORD2
+
 write	KEYWORD2
 
 available	KEYWORD2

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -256,7 +256,7 @@ int LoRaClass::parsePacket(int size)
 
 int LoRaClass::packetRssi()
 {
-  return (readRegister(REG_PKT_RSSI_VALUE) - (_frequency < 868E6 ? 164 : 157));
+  return (readRegister(REG_PKT_RSSI_VALUE) - (_frequency < 525E6 ? 164 : 157));
 }
 
 float LoRaClass::packetSnr()

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -20,6 +20,7 @@
 #define REG_RX_NB_BYTES          0x13
 #define REG_PKT_SNR_VALUE        0x19
 #define REG_PKT_RSSI_VALUE       0x1a
+#define REG_RSSI_VALUE           0x1b
 #define REG_MODEM_CONFIG_1       0x1d
 #define REG_MODEM_CONFIG_2       0x1e
 #define REG_PREAMBLE_MSB         0x20
@@ -54,6 +55,10 @@
 #define IRQ_TX_DONE_MASK           0x08
 #define IRQ_PAYLOAD_CRC_ERROR_MASK 0x20
 #define IRQ_RX_DONE_MASK           0x40
+
+#define RF_MID_BAND_THRESHOLD    525E6
+#define RSSI_OFFSET_HF_PORT      157
+#define RSSI_OFFSET_LF_PORT      164
 
 #define MAX_PKT_LENGTH           255
 
@@ -256,7 +261,7 @@ int LoRaClass::parsePacket(int size)
 
 int LoRaClass::packetRssi()
 {
-  return (readRegister(REG_PKT_RSSI_VALUE) - (_frequency < 525E6 ? 164 : 157));
+  return (readRegister(REG_PKT_RSSI_VALUE) - (_frequency < RF_MID_BAND_THRESHOLD ? RSSI_OFFSET_LF_PORT : RSSI_OFFSET_HF_PORT));
 }
 
 float LoRaClass::packetSnr()
@@ -281,6 +286,11 @@ long LoRaClass::packetFrequencyError()
   const float fError = ((static_cast<float>(freqError) * (1L << 24)) / fXtal) * (getSignalBandwidth() / 500000.0f); // p. 37
 
   return static_cast<long>(fError);
+}
+
+int LoRaClass::rssi()
+{
+  return (readRegister(REG_RSSI_VALUE) - (_frequency < RF_MID_BAND_THRESHOLD ? RSSI_OFFSET_LF_PORT : RSSI_OFFSET_HF_PORT));
 }
 
 size_t LoRaClass::write(uint8_t byte)

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -39,6 +39,8 @@ public:
   float packetSnr();
   long packetFrequencyError();
 
+  int rssi();
+
   // from Print
   virtual size_t write(uint8_t byte);
   virtual size_t write(const uint8_t *buffer, size_t size);


### PR DESCRIPTION
Mid band threshold used for RSSI calculation is wrong, causing incorrect RSSI values for frequencies on the HF band but below 868 MHz . Semtech reference code uses 525 MHz as threshold for RSSI calculation:
```
/*!
 * Constant values need to compute the RSSI value
 */
#define RSSI_OFFSET_LF                              -164.0
#define RSSI_OFFSET_HF                              -157.0
#define RF_MID_BAND_THRESH                          525000000
```
