### PR TITLE
RSSI when snr>0

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -256,8 +256,16 @@ int LoRaClass::parsePacket(int size)
 
 int LoRaClass::packetRssi()
 {
-  return (readRegister(REG_PKT_RSSI_VALUE) - (_frequency < 868E6 ? 164 : 157));
+int8_t snr =  ((int8_t)readRegister(REG_PKT_SNR_VALUE)) * 0.25;
+int8_t rssi =  readRegister(REG_PKT_RSSI_VALUE);
+
+  if(snr>0)
+  return (rssi + ( rssi >> 4 ) + snr - (_frequency < 868E6 ? 164 : 157)); 
+  
+  else
+  return (rssi + (rssi >> 4) - (_frequency < 868E6 ? 164 : 157));
 }
+
 
 float LoRaClass::packetSnr()
 {


### PR DESCRIPTION
Updated packetRSSI 
(RSSI=-139+16/15*PacketRssi) for cases when snr>0 
[https://www.mouser.com/ds/2/761/sx1276-1278113.pdf, Section 5.5.5 Note-3]