### PR TITLE
Version 0.7.1

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LoRa
-version=0.7.0
+version=0.7.1
 author=Sandeep Mistry <sandeep.mistry@gmail.com>
 maintainer=Sandeep Mistry <sandeep.mistry@gmail.com>
 sentence=An Arduino library for sending and receiving data using LoRa radios.


### PR DESCRIPTION
I would like to force a new version and work with the sandeepmistry /arduino-LoRa master repository.

I have a [project LoRaNow](https://github.com/ricaun/loranow) that uses a forked repository of arduino-LoRa and with the `depends=` on the `library.properties` file I could force the Arduino IDE to download the original repository.

But I use the `OnTxDone` function and version 0.7.0 doesn't have.

Could you force a new version?

I will appreciate that!
