### PR TITLE
Send ACK if required or requested by the sender

### DIFF
--- a/API.md
+++ b/API.md
@@ -242,6 +242,70 @@ Returns the next byte in the packet or `-1` if no bytes are available.
 
 **Note:** Other Arduino [`Stream` API's](https://www.arduino.cc/en/Reference/Stream) can also be used to read data from the packet
 
+### Reading to buffer
+
+Read the full packet into a given buffer.
+
+```arduino
+int packetSize = LoRa.parsePacket();
+int packet[packetSize];
+LoRa.readToBuffer(packet);
+```
+
+`packet` contains the full message including the header and payload.
+
+### Get header of packet
+
+Extract the header of the message from the packet content.
+
+```arduino
+int packetSize = LoRa.parsePacket();
+int packet[packetSize];
+LoRa.readToBuffer(packet);
+
+int rawHeader[HEADER_SIZE];	// HEADER_SIZE is pre-defined by LoRa.h
+LoRa.getPacketHeader(packet, rawHeader);
+```
+
+`rawHeader` contains the first N bytes of the message. With N = `HEADER_SIZE`.
+
+### Get payload of packet
+
+Extract the payload of the message from the complete packet content.
+
+```arduino
+int packetSize = LoRa.parsePacket();
+int packet[packetSize];
+LoRa.readToBuffer(packet);
+
+int rawPayload[packetSize-HEADER_SIZE];	// HEADER_SIZE is pre-defined by LoRa.h
+LoRa.getPacketMessage(packet, rawPayload, packetSize);
+```
+
+`rawPayload` contains the actual payload of the message without the header.
+
+### Send ACK
+
+Send an ACK back to the sender.
+
+```arduino
+byte localAddress = 0x2;	// address of this device
+
+int packetSize = LoRa.parsePacket();
+int packet[packetSize];
+LoRa.readToBuffer(packet);
+
+int rawHeader[HEADER_SIZE];	// HEADER_SIZE is pre-defined by LoRa.h
+LoRa.getPacketHeader(packet, rawHeader);
+
+LoRa.sendAck(rawHeader, localAddress);
+```
+
+The ACK is only sent if all three conditions are fullfiled:
+ * the received message is not a broadcast message
+ * the sender requested an ACK from the recipient
+ * this node is the addressed recipient
+
 ## Other radio modes
 
 ### Idle mode
@@ -375,3 +439,20 @@ byte b = LoRa.random();
 ```
 
 Returns random byte.
+
+### Get recipient of message
+
+Extract the recipient of the packet from the header content.
+
+```arduino
+int packetSize = LoRa.parsePacket();
+int packet[packetSize];
+LoRa.readToBuffer(packet);
+
+int rawHeader[HEADER_SIZE];	// HEADER_SIZE is pre-defined by LoRa.h
+LoRa.getPacketHeader(packet, rawHeader);
+
+uint8_t recipient = LoRa.getRecipient(rawHeader);
+```
+
+`recipient` contains the address of this message.

--- a/examples/ReceiveWithAck/ReceiveWithAck.ino
+++ b/examples/ReceiveWithAck/ReceiveWithAck.ino
@@ -1,0 +1,90 @@
+/*
+  ReceiveWithAck
+
+  Send ACK for a message back to the sender if requested.
+
+  The raw message is read into an array. Out of this array the message header
+  and the actual message payload (user data) is extracted.
+  If the address of this node is the recipient's address the ACK is
+  transmitted to the sender of the message.
+  This is only done if the message was not a broadcast message and the sender
+  requested an ACK from the receiver.
+
+  created 4 Nov 2020
+  by brainelectronics
+*/
+
+#include <SPI.h>
+#include <LoRa.h>
+
+byte localAddress = 0x2;        //< address of this device
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+
+  Serial.println("LoRa Receiver with ACK");
+
+  if (!LoRa.begin(915E6)) {         // initialize ratio at 915 MHz
+    Serial.println("LoRa init failed. Check your connections.");
+    while (true);                   // if failed, do nothing
+  }
+
+  Serial.println("LoRa init succeeded.");
+}
+
+void loop() {
+  // all magic happens here
+  onReceive(LoRa.parsePacket());
+}
+
+void onReceive(int packetSize)
+{
+  // if there's no packet, return
+  if (packetSize == 0) return;
+
+  // create different arrays
+  uint8_t packet[packetSize];                 // complete received message
+  uint8_t rawHeader[HEADER_SIZE];             // header of message
+
+  // read recieved bytes into buffer called 'packet'
+  LoRa.readToBuffer(packet);
+
+  // extract header from complete 'packet' into 'rawHeader' buffer
+  LoRa.getPacketHeader(packet, rawHeader);
+
+  // get the recipient of this message
+  uint8_t recipient = LoRa.getRecipient(rawHeader);
+
+  // compare the recipient with the address of this node
+  if (recipient != localAddress)
+  {
+    // this message is not for this node
+    Serial.print("This message is not for this node with ID ");
+    Serial.println(localAddress);
+    return;
+  }
+
+  // extract payload from complete 'packet' into 'rawPayload' buffer
+  uint8_t rawPayload[packetSize-HEADER_SIZE]; // payload of message
+  LoRa.getPacketMessage(packet, rawPayload, packetSize);
+
+  // print payload of message
+  printRawMessageData(rawPayload, packetSize);
+
+  // send an ACK back to the sender
+  LoRa.sendAck(rawHeader, localAddress);
+}
+
+void printRawMessageData(uint8_t *pPayload, uint8_t packetSize)
+{
+  Serial.print("Received (raw payload): '");
+
+  for (uint8_t i = 0; i < (packetSize-HEADER_SIZE); i++) {
+    Serial.print((char)pPayload[i]);
+  }
+
+  // print RSSI of packet
+  Serial.print("' with RSSI ");
+  Serial.println(LoRa.packetRssi());
+}

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -657,8 +657,18 @@ void LoRaClass::getPacketMessage(uint8_t *pBuffer, uint8_t *pMessage, uint8_t pa
   memcpy(pMessage, pBuffer+headerSize, (packetSize-headerSize)*sizeof(pBuffer[0]));
 }
 
-void LoRaClass::sendAck(uint8_t *pHeader)
+uint8_t LoRaClass::getRecipient(uint8_t *pHeader)
 {
+  return pHeader[0];
+}
+
+void LoRaClass::sendAck(uint8_t *pHeader, uint8_t localAddress)
+{
+  if (LoRa.getRecipient(pHeader) != localAddress)
+  {
+    return;
+  }
+
   // do not send an ACK is there has been no request (identifier is 0x0)
   // and this message is not a broadcast message
   if ((pHeader[2] != 0x0) && (pHeader[0] != BROADCAST_ADDRESS))

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -96,7 +96,8 @@ public:
   void readToBuffer(uint8_t *pBuffer);
   void getPacketHeader(uint8_t *pBuffer, uint8_t *pHeader, uint8_t headerSize = HEADER_SIZE);
   void getPacketMessage(uint8_t *pBuffer, uint8_t *pMessage, uint8_t packetSize, uint8_t headerSize = HEADER_SIZE);
-  void sendAck(uint8_t *pHeader);
+  uint8_t getRecipient(uint8_t *pHeader);
+  void sendAck(uint8_t *pHeader, uint8_t localAddress);
 private:
   void generateAckMessage(uint8_t *pHeader, uint8_t *pAckMessage);
 

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -21,7 +21,7 @@
 #define LORA_DEFAULT_DIO0_PIN      LORA_IRQ
 #else
 #define LORA_DEFAULT_SPI           SPI
-#define LORA_DEFAULT_SPI_FREQUENCY 8E6 
+#define LORA_DEFAULT_SPI_FREQUENCY 8E6
 #define LORA_DEFAULT_SS_PIN        10
 #define LORA_DEFAULT_RESET_PIN     9
 #define LORA_DEFAULT_DIO0_PIN      2
@@ -29,6 +29,9 @@
 
 #define PA_OUTPUT_RFO_PIN          0
 #define PA_OUTPUT_PA_BOOST_PIN     1
+
+#define BROADCAST_ADDRESS          0xFF
+#define HEADER_SIZE                4
 
 class LoRaClass : public Stream {
 public:
@@ -75,7 +78,7 @@ public:
   void disableCrc();
   void enableInvertIQ();
   void disableInvertIQ();
-  
+
   void setOCP(uint8_t mA); // Over Current Protection control
 
   // deprecated
@@ -90,7 +93,13 @@ public:
 
   void dumpRegisters(Stream& out);
 
+  void readToBuffer(uint8_t *pBuffer);
+  void getPacketHeader(uint8_t *pBuffer, uint8_t *pHeader, uint8_t headerSize = HEADER_SIZE);
+  void getPacketMessage(uint8_t *pBuffer, uint8_t *pMessage, uint8_t packetSize, uint8_t headerSize = HEADER_SIZE);
+  void sendAck(uint8_t *pHeader);
 private:
+  void generateAckMessage(uint8_t *pHeader, uint8_t *pAckMessage);
+
   void explicitHeaderMode();
   void implicitHeaderMode();
 


### PR DESCRIPTION
Add function to send an ACK back to the sender of this message if requested.

This is of course only done if:
 * the received message is not a broadcast message
 * the sender requested an ACK from the recipient
 * this node is the addressed recipient

Some other helpful functions are added as well.
* reading all available bytes into a given buffer
* extract header from received package
* extract message from received package
* get recipient of message