### PR TITLE
add function random(uint8_t *buffer, size_t size)

### DIFF
--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -87,6 +87,7 @@ public:
   void noCrc() { disableCrc(); }
 
   byte random();
+  void random(uint8_t *buffer, size_t size);
 
   void setPins(int ss = LORA_DEFAULT_SS_PIN, int reset = LORA_DEFAULT_RESET_PIN, int dio0 = LORA_DEFAULT_DIO0_PIN);
   void setSPI(SPIClass& spi);
@@ -111,6 +112,8 @@ private:
   uint8_t singleTransfer(uint8_t address, uint8_t value);
 
   static void onDio0Rise();
+
+  void random0(uint8_t *buffer, size_t size);
 
 private:
   SPISettings _spiSettings;


### PR DESCRIPTION
Hi,

I am included a function which returns an array of random bytes. This work is based on the work of @Kongduino and resolves the issue #394.
To get real random bytes one have to follow the guidelines given in Application Note AN1200.24 from Semtech.
See Chapter 4 of  [Random Number Generation for Cryptography](https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/440000001NAw/7YN8ZamV70_xR.vPDAAAshm.0Wt4jmRX0nOKkOzQqiI).

There is a setup described in this Application Note to be done before starting collecting random bits. These setup is done in function random(uint8 *, size_t) which then calls random0() to actually collect the random bytes.

The setup can be done in two ways:
- using the LoRa API or
- writing directly to the registers

Using the API will set some fancy values for sending or receiving but which are not needed for just measuring the RssiWideband for collecting random bits.  Writing directly to the registers will reduce much of the overhead due to setup for random number generations. But for review you will find both ways in the pull request:
- Setting "#define RANDOMUSEAPI" will use the API
- Unsetting "#define RANDOMUSEAPI" will write directly to the registers

There is one imported behavior of random(uint8 *, size_t). This function will memory the state before setup for random number generation and will reset to this state back at end. This is hidden for users of the library.

The old function random(byte) is still there and works now as expected. 