### PR TITLE
Changed rx and tx callbacks to std::function

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -359,7 +359,7 @@ void LoRaClass::flush()
 }
 
 #ifndef ARDUINO_SAMD_MKRWAN1300
-void LoRaClass::onReceive(void(*callback)(int))
+void LoRaClass::onReceive(std::function<void (int)> callback)
 {
   _onReceive = callback;
 
@@ -377,7 +377,7 @@ void LoRaClass::onReceive(void(*callback)(int))
   }
 }
 
-void LoRaClass::onTxDone(void(*callback)())
+void LoRaClass::onTxDone(std::function<void ()> callback)
 {
   _onTxDone = callback;
 

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -6,6 +6,7 @@
 
 #include <Arduino.h>
 #include <SPI.h>
+#include <functional>
 
 #if defined(ARDUINO_SAMD_MKRWAN1300)
 #define LORA_DEFAULT_SPI           SPI1
@@ -58,8 +59,8 @@ public:
   virtual void flush();
 
 #ifndef ARDUINO_SAMD_MKRWAN1300
-  void onReceive(void(*callback)(int));
-  void onTxDone(void(*callback)());
+  void onReceive(std::function<void (int)> callback);
+  void onTxDone(std::function<void ()> callback);
 
   void receive(int size = 0);
 #endif
@@ -121,8 +122,8 @@ private:
   long _frequency;
   int _packetIndex;
   int _implicitHeaderMode;
-  void (*_onReceive)(int);
-  void (*_onTxDone)();
+  std::function<void (int)> _onReceive;
+  std::function<void ()> _onTxDone;
 };
 
 extern LoRaClass LoRa;


### PR DESCRIPTION
By using `std::function` rather than function pointers, users can invoke
more complex callback functions such as non-static methods via the use of `std::bind`.

This is a backwards compatible change as function pointers coerce into `std::function`s. I've verfied as much by compiling and running an existing project and it works without any modifications.

I have not updated any documentation as it doesn't explicitly say "function pointer" which would now be wrong, just "function" which could mean `std::function`.