### PR TITLE
Add `packetSnrRaw` method to avoid floating-point

### DIFF
--- a/API.md
+++ b/API.md
@@ -204,6 +204,14 @@ float snr = LoRa.packetSnr();
 
 Returns the estimated SNR of the received packet in dB.
 
+### Packet SNR Raw
+
+```arduino
+int snrRaw = LoRa.packetSnrRaw();
+```
+
+Like [`LoRa.packetSnr()`](#packet-snr) except it returns an `int` that is 4 times the SNR of the received packet in dB.
+
 ## RSSI
 
 ```arduino

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -268,7 +268,12 @@ int LoRaClass::packetRssi()
 
 float LoRaClass::packetSnr()
 {
-  return ((int8_t)readRegister(REG_PKT_SNR_VALUE)) * 0.25;
+  return packetSnrRaw() * 0.25;
+}
+
+int LoRaClass::packetSnrRaw()
+{
+  return ((int8_t)readRegister(REG_PKT_SNR_VALUE));
 }
 
 long LoRaClass::packetFrequencyError()

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -43,6 +43,7 @@ public:
   int parsePacket(int size = 0);
   int packetRssi();
   float packetSnr();
+  int packetSnrRaw();
   long packetFrequencyError();
 
   int rssi();


### PR DESCRIPTION
This patch is motivated by a well known (#459, #460) limitation, that ESP microcontrollers can't use `float LoRa.packetSnr()` in ISR because that method performs a floating point operation.

My proposed solution is to add a method `int LoRa.packetSnrRaw()` that returns the `REG_PKT_SNR_VALUE` register as an `int` unmodified, rather than as a float divided by 4. I've written documentation for it noting that since it forgoes the division by 4, its value is 4 times the actual SNR.