### PR TITLE
Add LoRaClass::rxSignalDetected().

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -18,6 +18,7 @@
 #define REG_FIFO_RX_CURRENT_ADDR 0x10
 #define REG_IRQ_FLAGS            0x12
 #define REG_RX_NB_BYTES          0x13
+#define REG_MODEM_STAT           0x18
 #define REG_PKT_SNR_VALUE        0x19
 #define REG_PKT_RSSI_VALUE       0x1a
 #define REG_RSSI_VALUE           0x1b
@@ -288,6 +289,10 @@ long LoRaClass::packetFrequencyError()
   const float fError = ((static_cast<float>(freqError) * (1L << 24)) / fXtal) * (getSignalBandwidth() / 500000.0f); // p. 37
 
   return static_cast<long>(fError);
+}
+
+bool LoRaClass::rxSignalDetected() {
+  return (readRegister(REG_MODEM_STAT) & 0x01) == 0x01;
 }
 
 int LoRaClass::rssi()

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -44,6 +44,7 @@ public:
   int packetRssi();
   float packetSnr();
   long packetFrequencyError();
+  bool rxSignalDetected();
 
   int rssi();
 


### PR DESCRIPTION
Added function LoRaClass::rxSignalDetected() returns true when LoRa carrier is detected.

If you want to avoid collision,  you should not transmit during this function returns true.