### PR TITLE
Update README.md with working link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An [Arduino](https://arduino.cc/) library for sending and receiving data using [
 
 ## Compatible Hardware
 
- * [Semtech SX1276/77/78/79](https://www.semtech.com/apps/product.php?pn=SX1276) based boards including:
+ * [Semtech SX1276/77/78/79](https://www.semtech.com/products/wireless-rf/lora-connect/sx1276) based boards including:
    * [Dragino Lora Shield](https://www.dragino.com/products/lora/item/102-lora-shield.html)
    * [HopeRF](https://www.hoperf.com/modules/lora/index.html) [RFM95W](https://www.hoperf.com/modules/lora/RFM95.html), [RFM96W](https://www.hoperf.com/modules/lora/RFM96.html), and [RFM98W](https://www.hoperf.com/modules/lora/RFM98.html)
    * [Modtronix](http://modtronix.com/) [inAir4](http://modtronix.com/inair4.html), [inAir9](http://modtronix.com/inair9.html), and [inAir9B](http://modtronix.com/inair9b.html)


### PR DESCRIPTION
Update README.md with working link to SX127X Semtech website because old one is deprecated,