### PR TITLE
Moved ss pin toggling inside of spi transaction block.

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -765,14 +765,12 @@ uint8_t LoRaClass::singleTransfer(uint8_t address, uint8_t value)
 {
   uint8_t response;
 
-  digitalWrite(_ss, LOW);
-
   _spi->beginTransaction(_spiSettings);
+  digitalWrite(_ss, LOW);
   _spi->transfer(address);
   response = _spi->transfer(value);
-  _spi->endTransaction();
-
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return response;
 }


### PR DESCRIPTION
On the ESP32 platform, preventing concurrent access to the SPI peripheral is managed using a mutex in the SpiClass::beginTransaction and SpiClass::endTransaction functions. Toggling the _ss pin before this mutex is obtained can cause crosstalk between the LoRa module and another spi device. Moving the _ss pin toggling inside of the transaction block rectifies this. 