### PR TITLE
Force LDO option set or unset

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -47,6 +47,7 @@ setSignalBandwidth	KEYWORD2
 setCodingRate4	KEYWORD2
 setPreambleLength	KEYWORD2
 setSyncWord	KEYWORD2
+setLdoFlagForced	KEYWORD2
 enableCrc	KEYWORD2
 disableCrc	KEYWORD2
 enableInvertIQ	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -47,11 +47,12 @@ setSignalBandwidth	KEYWORD2
 setCodingRate4	KEYWORD2
 setPreambleLength	KEYWORD2
 setSyncWord	KEYWORD2
-setLdoFlagForced	KEYWORD2
 enableCrc	KEYWORD2
 disableCrc	KEYWORD2
 enableInvertIQ	KEYWORD2
 disableInvertIQ	KEYWORD2
+enableLowDataRateOptimize	KEYWORD2
+disableLowDataRateOptimize	KEYWORD2
 setGain	KEYWORD2
 
 random	KEYWORD2

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -649,7 +649,6 @@ void LoRaClass::disableLowDataRateOptimize()
    setLdoFlagForced(false);
 }
 
-
 void LoRaClass::setOCP(uint8_t mA)
 {
   uint8_t ocpTrim = 27;

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -639,6 +639,17 @@ void LoRaClass::disableInvertIQ()
   writeRegister(REG_INVERTIQ2, 0x1d);
 }
 
+void LoRaClass::enableLowDataRateOptimize()
+{
+   setLdoFlagForced(true);
+}
+
+void LoRaClass::disableLowDataRateOptimize()
+{
+   setLdoFlagForced(false);
+}
+
+
 void LoRaClass::setOCP(uint8_t mA)
 {
   uint8_t ocpTrim = 27;

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -586,6 +586,13 @@ void LoRaClass::setLdoFlag()
   writeRegister(REG_MODEM_CONFIG_3, config3);
 }
 
+void LoRaClass::setLdoFlagForced(const boolean ldoOn)
+{
+  uint8_t config3 = readRegister(REG_MODEM_CONFIG_3);
+  bitWrite(config3, 3, ldoOn);
+  writeRegister(REG_MODEM_CONFIG_3, config3);
+}
+
 void LoRaClass::setCodingRate4(int denominator)
 {
   if (denominator < 5) {

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -75,11 +75,13 @@ public:
   void setCodingRate4(int denominator);
   void setPreambleLength(long length);
   void setSyncWord(int sw);
-  void setLdoFlagForced(const boolean);
+
   void enableCrc();
   void disableCrc();
   void enableInvertIQ();
   void disableInvertIQ();
+  void enableLowDataRateOptimize();
+  void disableLowDataRateOptimize();
   
   void setOCP(uint8_t mA); // Over Current Protection control
   
@@ -124,6 +126,7 @@ private:
   long _frequency;
   int _packetIndex;
   int _implicitHeaderMode;
+  void setLdoFlagForced(const boolean);
   void (*_onReceive)(int);
   void (*_onCadDone)(boolean);
   void (*_onTxDone)();

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -75,6 +75,7 @@ public:
   void setCodingRate4(int denominator);
   void setPreambleLength(long length);
   void setSyncWord(int sw);
+  void setLdoFlagForced(const boolean);
   void enableCrc();
   void disableCrc();
   void enableInvertIQ();

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -75,7 +75,6 @@ public:
   void setCodingRate4(int denominator);
   void setPreambleLength(long length);
   void setSyncWord(int sw);
-
   void enableCrc();
   void disableCrc();
   void enableInvertIQ();
@@ -110,6 +109,7 @@ private:
   long getSignalBandwidth();
 
   void setLdoFlag();
+  void setLdoFlagForced(const boolean);
 
   uint8_t readRegister(uint8_t address);
   void writeRegister(uint8_t address, uint8_t value);
@@ -126,7 +126,6 @@ private:
   long _frequency;
   int _packetIndex;
   int _implicitHeaderMode;
-  void setLdoFlagForced(const boolean);
   void (*_onReceive)(int);
   void (*_onCadDone)(boolean);
   void (*_onTxDone)();


### PR DESCRIPTION
Some remote clients needs LDO using on any Spreading Factor. CDEbyte E32 (and similar) modules for example.